### PR TITLE
Remove caffe2

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -155,13 +155,6 @@ landscape:
             logo: 'https://valohai.com/static/img/support-logos/caffe.svg'
             crunchbase: 'https://www.crunchbase.com/organization/university-of-california-berkeley'
           - item:
-            name: Caffe2
-            homepage_url: 'https://caffe2.ai/'
-            repo_url: 'https://github.com/caffe2/caffe2'
-            twitter: 'https://twitter.com/caffe2ai'
-            crunchbase: 'https://www.crunchbase.com/organization/facebook'
-            logo: ./hosted_logos/caffe2.svg
-          - item:
             name: Chainer
             homepage_url: 'https://chainer.org/'
             repo_url: 'https://github.com/chainer/chainer'


### PR DESCRIPTION
Caffe2 has been moved into Pytorch and archived: https://github.com/facebookarchive/caffe2

Since we require a unique repo per project, remove caffe2:
```yml
          - item:
            name: Caffe2
            homepage_url: 'https://caffe2.ai/'
            repo_url: 'https://github.com/caffe2/caffe2'
            twitter: 'https://twitter.com/caffe2ai'
            crunchbase: 'https://www.crunchbase.com/organization/facebook'
            logo: ./hosted_logos/caffe2.svg
```
